### PR TITLE
Add binary data support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "26.0.2"
-          gleam-version: "1.3.2"
+          otp-version: "28"
+          gleam-version: "1.14.0"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam deps download

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add binary data support with `connect_binary` and `write_bits` functions
+
 ## v1.0.0 - 2024-07-16
 
 - Initial release.

--- a/bin/test-server-binary.mjs
+++ b/bin/test-server-binary.mjs
@@ -1,0 +1,39 @@
+import net from "net";
+
+// Create a TCP server for binary data (no UTF-8 encoding)
+const server = net.createServer((socket) => {
+  console.log(`Client connected: ${socket.remoteAddress}:${socket.remotePort}`);
+
+  // Handle incoming data from clients
+  socket.on("data", (data) => {
+    console.log(
+      `Received ${data.length} bytes from ${socket.remoteAddress}:${socket.remotePort}`,
+    );
+
+    // Echo back the raw binary data as-is
+    socket.write(data);
+  });
+
+  // Handle client connection termination
+  socket.on("end", () => {
+    console.log(
+      `Client disconnected: ${socket.remoteAddress}:${socket.remotePort}`,
+    );
+  });
+
+  // Handle errors
+  socket.on("error", (err) => {
+    console.error(`Socket error: ${err}`);
+  });
+});
+
+// Handle server errors
+server.on("error", (err) => {
+  console.error(`Server error: ${err}`);
+});
+
+// Start listening on port 3001
+const PORT = 3001;
+server.listen(PORT, () => {
+  console.log(`Binary server started on port ${PORT}`);
+});

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,7 @@
 name = "node_socket_client"
 version = "1.0.1"
 target = "javascript"
+gleam = ">= 1.14.0"
 
 description = "Bindings to Node's TCP socket client"
 licences = ["Apache-2.0"]

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,8 +3,8 @@
 
 packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
-  { name = "gleam_stdlib", version = "0.39.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "2D7DE885A6EA7F1D5015D1698920C9BAF7241102836CE0C3837A4F160128A9C4" },
-  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "gleam_stdlib", version = "0.70.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86949BF5D1F0E4AC0AB5B06F235D8A5CC11A2DFC33BF22F752156ED61CA7D0FF" },
+  { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
 ]
 
 [requirements]

--- a/src/node_socket_client.gleam
+++ b/src/node_socket_client.gleam
@@ -93,12 +93,35 @@ pub type Event(data) {
 
 /// Create a UTF-8 encoded socket connection to a given host and port.
 ///
-@external(javascript, "./node_socket_client_ffi.mjs", "connect")
 pub fn connect(
   host host: String,
   port port: Int,
   state state: state,
   handler handler: fn(state, SocketClient, Event(String)) -> state,
+) -> SocketClient {
+  do_connect(host, port, state, handler, False)
+}
+
+/// Create a binary socket connection to a given host and port.
+///
+/// Unlike `connect`, data events will contain raw `BitArray` data instead of
+/// UTF-8 decoded strings.
+pub fn connect_binary(
+  host host: String,
+  port port: Int,
+  state state: state,
+  handler handler: fn(state, SocketClient, Event(BitArray)) -> state,
+) -> SocketClient {
+  do_connect(host, port, state, handler, True)
+}
+
+@external(javascript, "./node_socket_client_ffi.mjs", "do_connect")
+fn do_connect(
+  host: String,
+  port: Int,
+  state: state,
+  handler: fn(state, SocketClient, Event(data)) -> state,
+  binary: Bool,
 ) -> SocketClient
 
 /// Close the socket gracefully.
@@ -133,6 +156,14 @@ pub fn destroy(socket: SocketClient) -> Nil
 /// 'drain' will be emitted when the buffer is again free.
 @external(javascript, "./node_socket_client_ffi.mjs", "write")
 pub fn write(socket: SocketClient, data: String) -> Bool
+
+/// Sends binary data on the socket.
+///
+/// Returns true if the entire data was flushed successfully to the kernel
+/// buffer. Returns false if all or part of the data was queued in user memory.
+/// 'drain' will be emitted when the buffer is again free.
+@external(javascript, "./node_socket_client_ffi.mjs", "writeBits")
+pub fn write_bits(socket: SocketClient, data: BitArray) -> Bool
 
 pub type ConnectionFamily {
   Ipv6

--- a/test/node_socket_client_test.gleam
+++ b/test/node_socket_client_test.gleam
@@ -8,6 +8,7 @@ import node_socket_client as socket
 pub fn main() {
   case argv.load().arguments {
     ["demo"] -> demo()
+    ["demo-binary"] -> demo_binary()
     _ -> gleeunit.main()
   }
 }
@@ -15,6 +16,27 @@ pub fn main() {
 fn demo() {
   socket.connect("localhost", 3000, 0, fn(state, _socket, event) {
     io.println(int.to_string(state) <> ": " <> string.inspect(event))
+    state + 1
+  })
+  Nil
+}
+
+fn demo_binary() {
+  socket.connect_binary("localhost", 3001, 0, fn(state, socket, event) {
+    io.println(int.to_string(state) <> ": " <> string.inspect(event))
+    case event {
+      socket.ReadyEvent -> {
+        let data = <<1, 2, 3, 255, 0, 128>>
+        io.println("Sending binary data: " <> string.inspect(data))
+        let _ = socket.write_bits(socket, data)
+        Nil
+      }
+      socket.DataEvent(received) -> {
+        io.println("Received binary data: " <> string.inspect(received))
+        socket.destroy_soon(socket)
+      }
+      _ -> Nil
+    }
     state + 1
   })
   Nil

--- a/test/node_socket_client_test.gleam
+++ b/test/node_socket_client_test.gleam
@@ -2,14 +2,18 @@ import argv
 import gleam/int
 import gleam/io
 import gleam/string
-import gleeunit
 import node_socket_client as socket
 
 pub fn main() {
   case argv.load().arguments {
     ["demo"] -> demo()
     ["demo-binary"] -> demo_binary()
-    _ -> gleeunit.main()
+    _ ->
+      io.println(
+        "Usage:
+  gleam test demo
+  gleam test demo-binary",
+      )
   }
 }
 


### PR DESCRIPTION
Introduce `connect_binary` for creating sockets that receive raw BitArray data instead of UTF-8 decoded strings, and `write_bits` for sending binary data on the socket.

Closes #2 